### PR TITLE
Adding turbostat for 60 seconds

### DIFF
--- a/packrat
+++ b/packrat
@@ -195,6 +195,9 @@ function collect_cpu_info() {
 
         popd > /dev/null
     fi
+
+    touch "${DEST}/turbostat.out"
+    turbostat > "${DEST}/turbostat.out" 2>&1 & sleep 60s; kill $!
 }
 
 function collect_device_info() {


### PR DESCRIPTION
Adding turbostat collection run for 60 seconds.

Yes, it will delay everything starting for 60 seconds.

Yes, I know there is a 'timeout' command in the current RHEL that does not have to be specially installed, but what I did should work on all systems.
