### PR TITLE
ignore infiniband device info when collecting network device data

### DIFF
--- a/packrat
+++ b/packrat
@@ -485,7 +485,7 @@ function collect_net_info() {
 		for SUBDIR in "device"; do
 		    if [ -d "${SUBDIR}" ]; then
 			if pushd "${SUBDIR}" > /dev/null; then
-			    for FILE in $(find . -type f -not -path "./net/*" | sort); do
+			    for FILE in $(find . -type f -not -path "./net/*" -and -not -path "./infiniband/*" | sort); do
 				append_str "${SUBDIR}/$(clean_path ${FILE}):" "${DEV_FILE}"
 				append_file "${FILE}" "${DEV_FILE}"
 				append_str "" "${DEV_FILE}"


### PR DESCRIPTION
- the data that would be collected it quite massive and not really
  relevant to the specific network device being queried (it covers all
  infiniband devices)

- if we want to collected infiniband data at some point there should
  be a targeted infiniband collector that can do this more
  intelligently