### PR TITLE
feat: add display step for changes action output

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -27,6 +27,8 @@ jobs:
             .github/workflows/run-crucible-tracking.yaml
             .github/workflows/crucible-ci.yaml
             docs/**
+      - name: Display changes
+        run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
   call-real-core-crucible-ci:
     needs: changes


### PR DESCRIPTION
## Summary

Add a Display changes step to log the full tj-actions/changed-files outputs for visibility in the GitHub UI.

Tracking: perftool-incubator/crucible#538

🤖 Generated with [Claude Code](https://claude.com/claude-code)