### PR TITLE
fix: write IOMMU data to IOMMU_FILE instead of CLOCKSOURCE_FILE

### DIFF
--- a/packrat
+++ b/packrat
@@ -317,9 +317,9 @@ function collect_kernel_info() {
 	    if pushd "${GROUP}" > /dev/null; then
 		local FILE=""
 		for FILE in $(find . -type f); do
-		    append_str "${GROUP}/$(clean_path ${FILE}):" "${CLOCKSOURCE_FILE}"
-		    append_file "${FILE}" "${CLOCKSOURCE_FILE}"
-		    append_str "" "${CLOCKSOURCE_FILE}"
+		    append_str "${GROUP}/$(clean_path ${FILE}):" "${IOMMU_FILE}"
+		    append_file "${FILE}" "${IOMMU_FILE}"
+		    append_str "" "${IOMMU_FILE}"
 		done
 
 		popd > /dev/null


### PR DESCRIPTION
## Summary

- Fix copy-paste bug where IOMMU data collection wrote to `${CLOCKSOURCE_FILE}` instead of `${IOMMU_FILE}`, leaving the `sys-class-iommu` output file empty

Closes #27

## Test plan
- [ ] Run packrat on a system with IOMMU enabled and verify `sys-class-iommu` contains data
- [ ] Verify `sys-devices-system-clocksource` no longer contains IOMMU data appended to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)