### PR TITLE
feat: add fork-check workflow

### DIFF
--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -1,0 +1,31 @@
+name: fork-check
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  block-fork-pr:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close fork PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'This PR was opened from a fork. PRs must be opened from branches on the upstream repository so that CI workflows have access to required secrets and variables.\n\nPlease push your branch to this repository and open a new PR.\n\nClosing this PR automatically.'
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });


### PR DESCRIPTION
## Summary
- Add `.github/workflows/fork-check.yaml`, blocking and auto-closing PRs opened from forks

`crucible-ci.yaml` passes organizational secrets (`CRUCIBLE_CI_ENGINES_REGISTRY_AUTH`, `CRUCIBLE_QUAYIO_OAUTH_TOKEN`) to a reusable workflow triggered on `pull_request`. This repo was missing the fork-check guard that every other secret-consuming repo in the org has.

Found during an org-wide audit of standard repo files/protections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)